### PR TITLE
chore: Update plugin test config and project tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Naming/VariableNumber:
   Enabled: false
 
 # This is used a lot across the fastlane code base for config files
-Style/MethodMissingSuper:
+Style/MissingSuper:
   Enabled: false
 
 Style/MissingRespondToMissing:
@@ -48,16 +48,12 @@ Style/TernaryParentheses:
 Style/EmptyMethod:
   Enabled: false
 
-# It's better to be more explicit about the type
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 # specs sometimes have useless assignments, which is fine
 Lint/UselessAssignment:
   Exclude:
     - '**/spec/**/*'
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # HoundCI doesn't like this rule
@@ -69,7 +65,7 @@ Style/DoubleNegation:
   Enabled: false
 
 # Sometimes we allow a rescue block that doesn't contain code
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 # Cop supports --auto-correct.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Gets PRODUCT_BUNDLE_IDENTIFIER from the first buildable target in a given scheme
 
 Check out the [example `Fastfile`](fastlane/Fastfile) to see how to use this plugin. Try it by cloning the repo, running `fastlane install_plugins` and `bundle exec fastlane test`.
 
+Or from the command line run:
+
+```bash
+fastlane run get_product_bundle_id project_filepath:CoinTossing.xcodeproj target:CoinTossingManager scheme:MoneyShakerManager build_configuration:"Debug Stage"
+```
+
 **Note to author:** Please set up a sample project to make it easy for users to explore what your plugin does. Provide everything that is necessary to try out the plugin in this project (including a sample Xcode/Android project if necessary)
 
 ## Run tests for this plugin

--- a/lib/fastlane/plugin/get_product_bundle_id/actions/get_product_bundle_id_action.rb
+++ b/lib/fastlane/plugin/get_product_bundle_id/actions/get_product_bundle_id_action.rb
@@ -11,15 +11,14 @@ module Fastlane
         project = Xcodeproj::Project.open(projectpath)
         targets = project.targets.find_all { |t| target_uuids.include?(t.uuid) }
         if params[:target].nil?
-          build_configuration = xcbuildconfiguration(targets.first, params[:build_configuration])
+          target = targets.first
         else
           target = targets.find { |t| t.name == params[:target] }
 
           UI.user_error!("Target '#{params[:target]}' does not exist in the given scheme") if target.nil?
-
-          build_configuration = xcbuildconfiguration(target, params[:build_configuration])
         end
-        build_configuration.build_settings['PRODUCT_BUNDLE_IDENTIFIER']
+
+        target.resolved_build_setting("PRODUCT_BUNDLE_IDENTIFIER")[params[:build_configuration]]
       end
 
       def self.xcscheme(params)

--- a/lib/fastlane/plugin/get_product_bundle_id/actions/get_product_bundle_id_action.rb
+++ b/lib/fastlane/plugin/get_product_bundle_id/actions/get_product_bundle_id_action.rb
@@ -17,8 +17,8 @@ module Fastlane
 
           UI.user_error!("Target '#{params[:target]}' does not exist in the given scheme") if target.nil?
         end
-
-        target.resolved_build_setting("PRODUCT_BUNDLE_IDENTIFIER")[params[:build_configuration]]
+        build_configuration = xcbuildconfiguration(target, params[:build_configuration])
+        build_configuration.build_settings['PRODUCT_BUNDLE_IDENTIFIER']
       end
 
       def self.xcscheme(params)

--- a/spec/fixtures/projects/CoinTossing/CoinTossing/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/spec/fixtures/projects/CoinTossing/CoinTossing/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,67 +2,92 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/spec/fixtures/projects/CoinTossing/CoinTossingUITests/CoinTossingUITests.swift
+++ b/spec/fixtures/projects/CoinTossing/CoinTossingUITests/CoinTossingUITests.swift
@@ -28,13 +28,8 @@ class CoinTossingUITests: XCTestCase {
         return result
     }
     
-    func testResultIsHeads() {
-        
-        XCTAssertEqual(tossResult(), "Heads")
-        
-    }
-    
-    func testResultIsTails() {
-        XCTAssertEqual(tossResult(), "Tails")
+    func testResultIsHeadsOrTails() {
+        let result = tossResult()
+        XCTAssert(result.isEqual("Heads") || result.isEqual("Tails"))
     }
 }

--- a/spec/fixtures/projects/CoinTossing/fastlane/Fastfile
+++ b/spec/fixtures/projects/CoinTossing/fastlane/Fastfile
@@ -7,7 +7,7 @@ lane :test do |options|
     scheme: scheme_to_test,
     device: 'iPhone 6',
     output_directory: 'artifacts/tests',
-    custom_report_file_name: 'report.xml'
+    output_files: 'report.xml'
   }
   begin
     retry_count ||= 0

--- a/spec/fixtures/projects/CoinTossing/fastlane/README.md
+++ b/spec/fixtures/projects/CoinTossing/fastlane/README.md
@@ -1,18 +1,30 @@
 fastlane documentation
-================
+----
+
 # Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
 ```
-sudo gem install fastlane
-```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
 # Available Actions
+
 ### test
+
+```sh
+[bundle exec] fastlane test
 ```
-fastlane test
-```
+
 
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
-More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).
-The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane/tree/master/fastlane).
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/spec/fixtures/projects/CoinTossing/fastlane/report.xml
+++ b/spec/fixtures/projects/CoinTossing/fastlane/report.xml
@@ -5,46 +5,7 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: scan" time="89.798227">
-        
-          <failure message="/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/actions/actions_helper.rb:48:in `execute_action'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:217:in `block in execute_action'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:213:in `chdir'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:213:in `execute_action'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:135:in `trigger_action_by_name'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/fast_file.rb:146:in `method_missing'&#10;Fastfile:12:in `block in parsing_binding'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/lane.rb:33:in `call'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:49:in `block in execute'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:45:in `chdir'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:45:in `execute'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/lane_manager.rb:52:in `cruise_lane'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/command_line_handler.rb:30:in `handle'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/commands_generator.rb:96:in `block (2 levels) in run'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/commander-4.4.3/lib/commander/command.rb:178:in `call'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/commander-4.4.3/lib/commander/command.rb:153:in `run'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/commander-4.4.3/lib/commander/runner.rb:446:in `run_active_command'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:38:in `run!'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/commander-4.4.3/lib/commander/delegates.rb:15:in `run!'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/commands_generator.rb:293:in `run'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/commands_generator.rb:36:in `start'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/cli_tools_distributor.rb:59:in `take_off'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/bin/fastlane:15:in `&lt;top (required)&gt;'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/bin/fastlane:22:in `load'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/bin/fastlane:22:in `&lt;main&gt;'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `eval'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `&lt;main&gt;'&#10;&#10;Test execution failed. Exit status: 65" />
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="1: setup_fragile_tests_for_rescan" time="0.036606">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="2: clear_derived_data" time="0.364895">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="3: scan" time="38.201509">
-        
-          <failure message="/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/actions/actions_helper.rb:48:in `execute_action'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:217:in `block in execute_action'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:213:in `chdir'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:213:in `execute_action'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:135:in `trigger_action_by_name'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/fast_file.rb:146:in `method_missing'&#10;Fastfile:12:in `block in parsing_binding'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/lane.rb:33:in `call'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:49:in `block in execute'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:45:in `chdir'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/runner.rb:45:in `execute'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/lane_manager.rb:52:in `cruise_lane'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/command_line_handler.rb:30:in `handle'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/commands_generator.rb:96:in `block (2 levels) in run'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/commander-4.4.3/lib/commander/command.rb:178:in `call'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/commander-4.4.3/lib/commander/command.rb:153:in `run'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/commander-4.4.3/lib/commander/runner.rb:446:in `run_active_command'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:38:in `run!'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/commander-4.4.3/lib/commander/delegates.rb:15:in `run!'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/commands_generator.rb:293:in `run'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/commands_generator.rb:36:in `start'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/fastlane/lib/fastlane/cli_tools_distributor.rb:59:in `take_off'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/gems/fastlane-2.8.0/bin/fastlane:15:in `&lt;top (required)&gt;'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/bin/fastlane:22:in `load'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/bin/fastlane:22:in `&lt;main&gt;'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `eval'&#10;/Users/shashi/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `&lt;main&gt;'&#10;&#10;Test execution failed. Exit status: 65" />
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="4: setup_fragile_tests_for_rescan" time="0.013882">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="5: clear_derived_data" time="0.047316">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="6: reset_simulator_contents" time="28.745269">
-        
-      </testcase>
-    
-      
-      <testcase classname="fastlane.lanes" name="7: scan" time="109.984408">
+      <testcase classname="fastlane.lanes" name="0: scan" time="17.115512">
         
       </testcase>
     


### PR DESCRIPTION
~Some configurations are inherted from other configs. So in that case the "PRODUCT_BUNDLE_IDENTIFIER" is not present. Therefore exits [resolved_build_setting](https://github.com/CocoaPods/Xcodeproj/blob/ab3dfa504b5a97cae3a653a8924f4616dcaa062e/lib/xcodeproj/project/object/native_target.rb#L54).~

Edit:
- Update outdated plugin test config options
- Update test project to not fail
- Update README to support command line
- Minor optimization on assigning `target`
- Update generated files